### PR TITLE
parse-env-file.js

### DIFF
--- a/lib/parse-env-file.js
+++ b/lib/parse-env-file.js
@@ -10,7 +10,8 @@ const parseEnvFile = file => {
   const content = fs.readFileSync(file).toString();
 
   return content.split(/\r|\n/).reduce((variables, row) => {
-    const parts = row.split('=');
+
+    const parts = [row.substring(0,row.indexOf("=")),row.substring(row.indexOf("=")+1)];
 
     if (parts[0] && parts[1]) {
       let varName = parts[0].trim();


### PR DESCRIPTION
row.split('=') causes issue when we are giving any URL with  "=" symbol