### PR TITLE
Accept any arguments after react-scripts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,8 @@ if (reactScriptsCommand === 'test') {
     const args = [].concat(argv._);
     args.shift();
     rest.push(...args);
-    rest.push('--env=jsdom');
   }
+  rest.push('--env=jsdom');
 }
 
 const envFile = argv.envFile || defaultEnvFile;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,12 @@ if (reactScriptsCommand == 'build') {
 
 const rest = [];
 if (reactScriptsCommand === 'test') {
-  if (argv._.includes('--coverage')) rest.push('--coverage');
-  rest.push('--env=jsdom');
+  if (argv._.length > 1) {
+    const args = [].concat(argv._);
+    args.shift();
+    rest.push(...args);
+    rest.push('--env=jsdom');
+  }
 }
 
 const envFile = argv.envFile || defaultEnvFile;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ if (reactScriptsCommand == 'build') {
 
 const rest = [];
 if (reactScriptsCommand === 'test') {
+  if (argv._.includes('--coverage')) rest.push('--coverage');
   rest.push('--env=jsdom');
 }
 
@@ -25,5 +26,5 @@ const env = Object.keys(variables).reduce((env, variable) => {
 }, []);
 
 spawn('cross-env', [...env, 'react-scripts', reactScriptsCommand, ...rest], {
-  stdio: 'inherit',
+  stdio: 'inherit'
 });


### PR DESCRIPTION
**Problem**
My problem is accept flag `--coverage`, but is not support.

**Solution**
This implementation add support any argument after read environments and run react-scripts.

```shell
# npm scripts
# "test": "CI=true react-app-env --env-file=.env.test test -- --coverage --watchAll"
# Output

[
  'REACT_APP_ENV="production"'
  'react-scripts',
  'test',
  '--coverage',
  '--watch',
  '--env=jsdom' 
]
```

Close #5 