### PR TITLE
Add other global variables like `BROWSER` to not get the `REACT_APP_` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ PORT = 9001
 ```
 *react-app-env* will automatically add `REACT_APP` prefix to each env variable except:
 
-* PORT - dev server port
-* NODE_PATH - directory name to be resolved to the current directory as well as its ancestors, and searched for modules. It is [resolve.modulesDirectories](https://webpack.github.io/docs/configuration.html#resolve-modulesdirectories) for webpack. More details at node official doc ["Loading from the global folders"](https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders)
+`BROWSER`, `HOST`, `PORT`, `HTTPS`, `PUBLIC_URL`, `CI`, `REACT_EDITOR`, `CHOKIDAR_USEPOLLING`, `GENERATE_SOURCEMAP`, `NODE_PATH`, `INLINE_RUNTIME_CHUNK`
+For explaination see here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
 
 With this environment file defined above:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ PORT = 9001
 *react-app-env* will automatically add `REACT_APP` prefix to each env variable except:
 
 `BROWSER`, `HOST`, `PORT`, `HTTPS`, `PUBLIC_URL`, `CI`, `REACT_EDITOR`, `CHOKIDAR_USEPOLLING`, `GENERATE_SOURCEMAP`, `NODE_PATH`, `INLINE_RUNTIME_CHUNK`
+
 For explaination see here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
 
 With this environment file defined above:

--- a/lib/parse-env-file.js
+++ b/lib/parse-env-file.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const EXPECT_VARIABLES = ['PORT', 'NODE_PATH'];
+const EXPECT_VARIABLES = ['BROWSER', 'HOST', 'PORT', 'HTTPS', 'PUBLIC_URL', 'CI', 'REACT_EDITOR', 'CHOKIDAR_USEPOLLING', 'GENERATE_SOURCEMAP', 'NODE_PATH', 'INLINE_RUNTIME_CHUNK'];
 
 const parseEnvFile = file => {
   if (!fs.existsSync(file)) {


### PR DESCRIPTION
**Problem**
my problem is that the variable `BROWSER` gets a prefix of `REACT_APP_` even though it is not supposed to have one, to be recognized

**Solution**
Add other global variables from https://facebook.github.io/create-react-app/docs/advanced-configuration, so that they do not get a prefix like all the others do.