### PR TITLE
Handle PUBLIC_URL variable differently

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -16,7 +16,8 @@ describe('parse env variables', () => {
       "REACT_APP_API_SECURITY_TOKEN": "access_token",
 
       "NODE_PATH": "/src",
-      "PORT": "9001"
+      "PORT": "9001",
+      "PUBLIC_URL": "/dummy"
     });
   });
 });

--- a/__tests__/variables.env
+++ b/__tests__/variables.env
@@ -6,4 +6,5 @@ API_PREFIX = api
 API_SECURITY_TOKEN = access_token
 
 NODE_PATH = /src
+PUBLIC_URL = /dummy
 PORT = 9001

--- a/lib/parse-env-file.js
+++ b/lib/parse-env-file.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const EXPECT_VARIABLES = ['PORT', 'NODE_PATH'];
+const EXPECT_VARIABLES = ['PORT', 'NODE_PATH', 'PUBLIC_URL'];
 
 const parseEnvFile = file => {
   if (!fs.existsSync(file)) {


### PR DESCRIPTION
PUBLIC_URL is one of variables that doesn't need REACT_APP_ prefix